### PR TITLE
Fix CI using ubuntu image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,16 @@ version: 2.1
 executors:
   main:
     docker:
-      - image: debian:buster
+      - image: ubuntu:focal-20201106
+        auth:
+          username: $DOCKER_HUB_LOGIN
+          password: $DOCKER_HUB_PASSWORD
 
 jobs:
   build:
     executor: main
     environment:
+      DEBIAN_FRONTEND: noninteractive
     steps:
       # setup bazel
       - run: echo 'export GOPATH="/go"' >> $BASH_ENV
@@ -27,4 +31,6 @@ jobs:
 workflows:
   build:
     jobs:
-      - build
+      - build:
+          context:
+            - docker-hub-credentials

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,6 @@ executors:
   main:
     docker:
       - image: ubuntu:focal-20201106
-        auth:
-          username: $DOCKER_HUB_LOGIN
-          password: $DOCKER_HUB_PASSWORD
 
 jobs:
   build:
@@ -31,6 +28,4 @@ jobs:
 workflows:
   build:
     jobs:
-      - build:
-          context:
-            - docker-hub-credentials
+      - build


### PR DESCRIPTION
The failure in the CI is because the CI uses Go 1.11 but to build bazelisk from master Go 1.12 is required bazelbuild/bazelisk#206
This ubuntu image has Go 1.12
Fixes #10 