### PR TITLE
fix possible file naming collision in qt_resource()

### DIFF
--- a/tests/qt_resource/BUILD
+++ b/tests/qt_resource/BUILD
@@ -12,7 +12,7 @@ qt_resource(
 # For now, test with:
 #   bazel run //tests/qt_resource:main
 cc_binary(
-    name = "main",
+    name = "example",
     srcs = ["main.cc"],
     deps = [
         ":resources",


### PR DESCRIPTION
After https://github.com/justbuchanan/bazel_rules_qt/pull/11, I noticed an issue that arises when you have a target inside a folder of the same name. I think changing the paths of intermediates used in the gencpp rule should fix this.

Here's what I get from this PR (changing `//example:main` to `//example:example`):

```
ERROR: output path 'bazel-out/k8-fastbuild/bin/example/example' (belonging to //example:example) is a prefix of output path 'bazel-out/k8-fastbuild/bin/example/example/subdir/file2.txt' (belonging to //example:resources_gen). These actions cannot be simultaneously present; please rename one of the output files or build just one of them
ERROR: com.google.devtools.build.lib.skyframe.ArtifactConflictFinder$ConflictException: com.google.devtools.build.lib.actions.ArtifactPrefixConflictException: output path 'bazel-out/k8-fastbuild/bin/example/example' (belonging to //example:example) is a prefix of output path 'bazel-out/k8-fastbuild/bin/example/example/subdir/file2.txt' (belonging to //example:resources_gen). These actions cannot be simultaneously present; please rename one of the output files or build just one of them
INFO: Elapsed time: 0.106s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded, 0 targets configured)
```