### PR TITLE
Add Bazel CI file

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,11 @@
+---
+tasks:
+  ubuntu1804:
+    shell_commands:
+      - pip3 install aqtinstall
+      - python3 -m aqt install --outputdir $HOME/Qt 5.12.10 linux desktop
+    environment:
+      # Ideally we would write $HOME/Qt/5.12.10/gcc_64 but variable substitution is not happening
+      QT_DIR: /var/lib/buildkite-agent/Qt/5.12.10/gcc_64
+    build_targets:
+      - "//..."


### PR DESCRIPTION
This is a first version on how could look the Bazel CI file. The problem is that Qt is not installed on the system with the Bazel CI.
With this approach Qt is installed standalone, meaning that in one folder there are the bin, lib and include folders.
This makes that the binaries are not in the path and the libs are not by default available by the compiler.

This means that until rules_qt do not support standalone installation, this will not work. However I create this PR in case we already want to start the preparation.