### PR TITLE
Add logic to autodetect the host os

### DIFF
--- a/BUILD.local_qt.tpl
+++ b/BUILD.local_qt.tpl
@@ -1,0 +1,2 @@
+def local_qt_path():
+    return "%{path}"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,8 +1,13 @@
 workspace(name = "com_justbuchanan_rules_qt")
 
+load("@com_justbuchanan_rules_qt//:qt_configure.bzl", "qt_configure")
+
+qt_configure()
+
+load("@local_config_qt//:local_qt.bzl", "local_qt_path")
+
 new_local_repository(
     name = "qt",
     build_file = "@com_justbuchanan_rules_qt//:qt.BUILD",
-    # path = "/usr/include/qt",  # arch linux
-    path = "/usr/include/x86_64-linux-gnu/qt5",  # debian
+    path = local_qt_path(),
 )

--- a/qt_configure.bzl
+++ b/qt_configure.bzl
@@ -1,0 +1,27 @@
+def qt_autoconf_impl(repository_ctx):
+    """
+    Generate BUILD file with 'local_qt_path' function to get the Qt local path.
+
+    Args:
+       repository_ctx: repository context
+    """
+    os_name = repository_ctx.os.name.lower()
+    qt_path = "dummy"
+    if os_name.find("windows") != -1:
+        qt_path = "C:\\\\Qt\\\\5.9.9\\\\msvc2017_64\\\\"
+    else:
+        qt_path = "/usr/include/x86_64-linux-gnu/qt5"
+    repository_ctx.file("BUILD", "# empty BUILD file so that bazel sees this as a valid package directory")
+    repository_ctx.template(
+        "local_qt.bzl",
+        repository_ctx.path(Label("//:BUILD.local_qt.tpl")),
+        {"%{path}": qt_path},
+    )
+
+qt_autoconf = repository_rule(
+    implementation = qt_autoconf_impl,
+    configure = True,
+)
+
+def qt_configure():
+    qt_autoconf(name = "local_config_qt")


### PR DESCRIPTION
This is the first to detect the Qt local installation, for the moment
the windows path is hardcoded but this should show that the auto
detection works.
This would allow adding windows in the CI using the same WORKSPACE file