### PR TITLE
initial setup of bazel toolchain for qt

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,7 @@
 workspace(name = "com_justbuchanan_rules_qt")
 
 load("@com_justbuchanan_rules_qt//:qt_configure.bzl", "qt_configure")
+load("@com_justbuchanan_rules_qt//tools:qt_toolchain.bzl", "register_qt_toolchains")
 
 qt_configure()
 
@@ -12,7 +13,4 @@ new_local_repository(
     path = local_qt_path(),
 )
 
-register_toolchains(
-    "//tools:qt_linux_toolchain",
-    "//tools:qt_windows_toolchain",
-)
+register_qt_toolchains()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,3 +11,8 @@ new_local_repository(
     build_file = "@com_justbuchanan_rules_qt//:qt.BUILD",
     path = local_qt_path(),
 )
+
+register_toolchains(
+    "//tools:qt_linux_toolchain",
+    "//tools:qt_windows_toolchain",
+)

--- a/qt.BUILD
+++ b/qt.BUILD
@@ -99,12 +99,14 @@ cc_library(
     # target_compatible_with = ["@platforms//os:linux"],
 )
 
+# TODO: remove in favor of toolchain-defined binary
 filegroup(
     name = "uic",
     srcs = ["bin/uic.exe"],
     visibility = ["//visibility:public"],
 )
 
+# TODO: remove in favor of toolchain-defined binary
 filegroup(
     name = "moc",
     srcs = ["bin/moc.exe"],

--- a/qt.bzl
+++ b/qt.bzl
@@ -46,7 +46,7 @@ def qt_ui_library(name, ui, deps, **kwargs):
     )
 
 def _gencpp(ctx):
-    info = ctx.toolchains["//tools:qt_toolchain_type"].qtinfo
+    info = ctx.toolchains["@com_justbuchanan_rules_qt//tools:qt_toolchain_type"].qtinfo
 
     resource_files = [(f, ctx.actions.declare_file(f.path)) for f in ctx.files.files]
     for target_file, output in resource_files:
@@ -72,7 +72,7 @@ gencpp = rule(
         "qrc": attr.label(allow_single_file = True, mandatory = True),
         "cpp": attr.output(),
     },
-    toolchains = ["//tools:qt_toolchain_type"],
+    toolchains = ["@com_justbuchanan_rules_qt//tools:qt_toolchain_type"],
 )
 
 # generate a qrc file that lists each of the input files.

--- a/qt.bzl
+++ b/qt.bzl
@@ -46,7 +46,7 @@ def qt_ui_library(name, ui, deps, **kwargs):
     )
 
 def _gencpp(ctx):
-    info = ctx.toolchains["@com_justbuchanan_rules_qt//tools:qt_toolchain_type"].qtinfo
+    info = ctx.toolchains["@com_justbuchanan_rules_qt//tools:toolchain_type"].qtinfo
 
     resource_files = [(f, ctx.actions.declare_file(f.path)) for f in ctx.files.files]
     for target_file, output in resource_files:
@@ -72,7 +72,7 @@ gencpp = rule(
         "qrc": attr.label(allow_single_file = True, mandatory = True),
         "cpp": attr.output(),
     },
-    toolchains = ["@com_justbuchanan_rules_qt//tools:qt_toolchain_type"],
+    toolchains = ["@com_justbuchanan_rules_qt//tools:toolchain_type"],
 )
 
 # generate a qrc file that lists each of the input files.

--- a/qt.bzl
+++ b/qt.bzl
@@ -46,6 +46,8 @@ def qt_ui_library(name, ui, deps, **kwargs):
     )
 
 def _gencpp(ctx):
+    info = ctx.toolchains["//tools:qt_toolchain_type"].qtinfo
+
     resource_files = [(f, ctx.actions.declare_file(f.path)) for f in ctx.files.files]
     for target_file, output in resource_files:
         ctx.actions.symlink(
@@ -58,7 +60,7 @@ def _gencpp(ctx):
         inputs = [resource for _, resource in resource_files] + [ctx.file.qrc],
         outputs = [ctx.outputs.cpp],
         arguments = args,
-        executable = "rcc",
+        executable = info.rcc_path,
     )
     return [OutputGroupInfo(cpp = depset([ctx.outputs.cpp]))]
 
@@ -70,6 +72,7 @@ gencpp = rule(
         "qrc": attr.label(allow_single_file = True, mandatory = True),
         "cpp": attr.output(),
     },
+    toolchains = ["//tools:qt_toolchain_type"],
 )
 
 # generate a qrc file that lists each of the input files.

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ Configure your WORKSPACE to include the qt libraries:
 # WORKSPACE
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@com_justbuchanan_rules_qt//tools:qt_toolchain.bzl", "register_qt_toolchains")
 
 git_repository(
     name = "com_justbuchanan_rules_qt",
@@ -39,6 +40,8 @@ new_local_repository(
     # For Qt5 on Ubuntu 16.04
     # path = "/usr/include/x86_64-linux-gnu/qt5/"
 )
+
+register_qt_toolchains()
 ```
 
 Use the build rules provided by qt.bzl to build your project. See qt.bzl for which rules are available.

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,3 +1,5 @@
+package(default_visibility = ["//visibility:public"])
+
 load(":qt_toolchain.bzl", "qt_toolchain")
 
 toolchain_type(name = "toolchain_type")
@@ -27,7 +29,7 @@ toolchain(
         "@platforms//os:linux",
     ],
     toolchain = ":qt_linux",
-    toolchain_type = ":toolchain_type",
+    toolchain_type = "@com_justbuchanan_rules_qt//tools:toolchain_type",
 )
 
 toolchain(
@@ -39,5 +41,5 @@ toolchain(
         "@platforms//os:windows",
     ],
     toolchain = ":qt_windows",
-    toolchain_type = ":toolchain_type",
+    toolchain_type = "@com_justbuchanan_rules_qt//tools:toolchain_type",
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,0 +1,43 @@
+load(":qt_toolchain.bzl", "qt_toolchain")
+
+toolchain_type(name = "qt_toolchain_type")
+
+qt_toolchain(
+    name = "qt_linux",
+    # TODO: determine paths in qt_configure.bzl
+    moc_path = "/usr/bin/moc",
+    rcc_path = "/usr/bin/rcc",
+    uic_path = "/usr/bin/uic",
+)
+
+qt_toolchain(
+    name = "qt_windows",
+    # TODO: determine paths in qt_configure.bzl
+    moc_path = "moc",
+    rcc_path = "rcc",
+    uic_path = "uic",
+)
+
+toolchain(
+    name = "qt_linux_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
+    toolchain = ":qt_linux",
+    toolchain_type = ":qt_toolchain_type",
+)
+
+toolchain(
+    name = "qt_windows_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:windows",
+    ],
+    target_compatible_with = [
+        "@platforms//os:windows",
+    ],
+    toolchain = ":qt_windows",
+    toolchain_type = ":qt_toolchain_type",
+)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -27,6 +27,7 @@ toolchain(
     ],
     target_compatible_with = [
         "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
     toolchain = ":qt_linux",
     toolchain_type = "@com_justbuchanan_rules_qt//tools:toolchain_type",
@@ -39,6 +40,7 @@ toolchain(
     ],
     target_compatible_with = [
         "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
     ],
     toolchain = ":qt_windows",
     toolchain_type = "@com_justbuchanan_rules_qt//tools:toolchain_type",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,6 +1,6 @@
 load(":qt_toolchain.bzl", "qt_toolchain")
 
-toolchain_type(name = "qt_toolchain_type")
+toolchain_type(name = "toolchain_type")
 
 qt_toolchain(
     name = "qt_linux",
@@ -27,7 +27,7 @@ toolchain(
         "@platforms//os:linux",
     ],
     toolchain = ":qt_linux",
-    toolchain_type = ":qt_toolchain_type",
+    toolchain_type = ":toolchain_type",
 )
 
 toolchain(
@@ -39,5 +39,5 @@ toolchain(
         "@platforms//os:windows",
     ],
     toolchain = ":qt_windows",
-    toolchain_type = ":qt_toolchain_type",
+    toolchain_type = ":toolchain_type",
 )

--- a/tools/qt_toolchain.bzl
+++ b/tools/qt_toolchain.bzl
@@ -1,11 +1,11 @@
-QtToolsInfo = provider(
+QtToolchainInfo = provider(
     doc = "Information about how to invoke qt tools.",
     fields = ["rcc_path", "uic_path", "moc_path"],
 )
 
 def _qt_toolchain_impl(ctx):
     toolchain_info = platform_common.ToolchainInfo(
-        qtinfo = QtToolsInfo(
+        qtinfo = QtToolchainInfo(
             rcc_path = ctx.attr.rcc_path,
             uic_path = ctx.attr.uic_path,
             moc_path = ctx.attr.moc_path,

--- a/tools/qt_toolchain.bzl
+++ b/tools/qt_toolchain.bzl
@@ -1,0 +1,23 @@
+QtToolsInfo = provider(
+    doc = "Information about how to invoke qt tools.",
+    fields = ["rcc_path", "uic_path", "moc_path"],
+)
+
+def _qt_toolchain_impl(ctx):
+    toolchain_info = platform_common.ToolchainInfo(
+        qtinfo = QtToolsInfo(
+            rcc_path = ctx.attr.rcc_path,
+            uic_path = ctx.attr.uic_path,
+            moc_path = ctx.attr.moc_path,
+        ),
+    )
+    return [toolchain_info]
+
+qt_toolchain = rule(
+    implementation = _qt_toolchain_impl,
+    attrs = {
+        "rcc_path": attr.string(),
+        "uic_path": attr.string(),
+        "moc_path": attr.string(),
+    },
+)

--- a/tools/qt_toolchain.bzl
+++ b/tools/qt_toolchain.bzl
@@ -24,6 +24,6 @@ qt_toolchain = rule(
 
 def register_qt_toolchains():
     native.register_toolchains(
-        "//tools:qt_linux_toolchain",
-        "//tools:qt_windows_toolchain",
+        "@com_justbuchanan_rules_qt//tools:qt_linux_toolchain",
+        "@com_justbuchanan_rules_qt//tools:qt_windows_toolchain",
     )

--- a/tools/qt_toolchain.bzl
+++ b/tools/qt_toolchain.bzl
@@ -21,3 +21,9 @@ qt_toolchain = rule(
         "moc_path": attr.string(),
     },
 )
+
+def register_qt_toolchains():
+    native.register_toolchains(
+        "//tools:qt_linux_toolchain",
+        "//tools:qt_windows_toolchain",
+    )


### PR DESCRIPTION
The goal is to separate rule implementations from the platform-specific
binaries and settings needed. To start, the toolchain provides
hard-coded paths to the moc, rcc, and uic tools. tools/BUILD provides
separate values for Windows and Linux.

The next step, I think, is to use qt_configure.bzl to dynamically
determine the paths to these tools on the current system.

Bazel docs on toolchains: https://docs.bazel.build/versions/master/toolchains.html.