### PR TITLE
Add support for other Qt versions on Window, e.g. Qt 5.12.10

### DIFF
--- a/qt_configure.bzl
+++ b/qt_configure.bzl
@@ -17,6 +17,13 @@ def qt_autoconf_impl(repository_ctx):
     if os_name.find("windows") != -1:
         # Inside this folder, in Windows you can find include, lib and bin folder
         default_qt_path = "C:\\\\Qt\\\\5.9.9\\\\msvc2017_64\\\\"
+        # If predefined path does not exist search for an alternative e.g. "C:\\\\Qt\\\\5.12.10\\\\msvc2017_64\\\\"
+        if not repository_ctx.path(default_qt_path).exists:
+            win_path_env = _get_env_var(repository_ctx, "PATH")
+            start_index = win_path_env.index("C:\\Qt\\5.")
+            end_index = win_path_env.index("msvc2017_64\\", start_index) + len("msvc2017_64")
+            default_qt_path = win_path_env[start_index:end_index+1]
+            default_qt_path = default_qt_path.replace('\\', "\\\\")
     elif os_name.find("linux") != -1:
         is_linux_machine = True
 

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,6 @@ Configure your WORKSPACE to include the qt libraries:
 # WORKSPACE
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@com_justbuchanan_rules_qt//tools:qt_toolchain.bzl", "register_qt_toolchains")
 
 git_repository(
     name = "com_justbuchanan_rules_qt",
@@ -33,14 +32,19 @@ git_repository(
     branch = "master",
 )
 
+load("@com_justbuchanan_rules_qt//:qt_configure.bzl", "qt_configure")
+
+qt_configure()
+
+load("@local_config_qt//:local_qt.bzl", "local_qt_path")
+
 new_local_repository(
     name = "qt",
     build_file = "@com_justbuchanan_rules_qt//:qt.BUILD",
-    path = "/usr/include/qt", # May need configuring for your installation
-    # For Qt5 on Ubuntu 16.04
-    # path = "/usr/include/x86_64-linux-gnu/qt5/"
+    path = local_qt_path(),
 )
 
+load("@com_justbuchanan_rules_qt//tools:qt_toolchain.bzl", "register_qt_toolchains")
 register_qt_toolchains()
 ```
 


### PR DESCRIPTION
* Currently, on Windows, only `C:\Qt\5.9.9\msvc2017_64\` is considered as a Qt location. This does apparently not work if only some other version such as Qt 5.12.10 is installed. This PR fixes this issue by searching the environment `PATH` variable for the pattern `C:\Qt\5.*\msvc2017_64`.  
* Documentation about Usage in Readme seems to be not up to date - fixed that